### PR TITLE
Add `context` that defines request state with `StateManager`

### DIFF
--- a/chain.go
+++ b/chain.go
@@ -6,6 +6,12 @@ import (
 	"path"
 )
 
+type Options struct {
+	header map[string]string
+	query  map[string][]string
+	sync   bool
+}
+
 type Fchain struct {
 	chain    *sdk.Chain
 	id       string
@@ -14,22 +20,9 @@ type Fchain struct {
 	chainDef []byte
 }
 
-type Context struct {
-	phaseInput []byte
-	requestId  string
-	phase      int
-}
-
-type Options struct {
-	header map[string]string
-	query  map[string][]string
-	sync   bool
-}
-
 type Option func(*Options)
 
 var (
-	gContext *Context
 	// Sync can be used instead of SyncCall
 	Sync = SyncCall()
 )
@@ -215,35 +208,4 @@ func (fchain *Fchain) GetUrl() string {
 // GetAsyncUrl returns the URL for the faaschain async function
 func (fchain *Fchain) GetAsyncUrl() string {
 	return fchain.asyncUrl
-}
-
-// CreateGlobalContext create a context for the chain (it's
-func (fchain *Fchain) CreateGlobalContext(request []byte) {
-	if gContext == nil {
-		context := &Context{}
-		context.phaseInput = request
-		context.requestId = fchain.id
-		context.phase = fchain.chain.ExecutionPosition + 1
-		gContext = context
-	}
-}
-
-// GetContext returns the global context that was created
-func GetContext() Context {
-	return *gContext
-}
-
-// GetPhaseInput returns the phase input (it allows to user replay a data )
-func (context Context) GetPhaseInput() []byte {
-	return context.phaseInput
-}
-
-// GetRequestId returns the request id
-func (context Context) GetRequestId() string {
-	return context.requestId
-}
-
-// GetPhase return the phase no
-func (context Context) GetPhase() int {
-	return context.phase
 }

--- a/context.go
+++ b/context.go
@@ -5,6 +5,7 @@ type Context struct {
 	requestId    string
 	phase        int
 	stateManager StateManager
+	State        string
 }
 
 // StateManager for State Manager
@@ -14,11 +15,18 @@ type StateManager interface {
 	Del(key string) error
 }
 
+const (
+	StateSuccess = "success"
+	StateFailure = "failure"
+	StateOngoing = "ongoing"
+)
+
 // CreateContext create request context (used by template)
 func CreateContext(fchain *Fchain) *Context {
 	context := &Context{}
 	context.requestId = fchain.id
 	context.phase = fchain.chain.ExecutionPosition + 1
+	context.State = StateOngoing
 	return context
 }
 

--- a/context.go
+++ b/context.go
@@ -1,0 +1,54 @@
+package faaschain
+
+// Context execution context and execution state
+type Context struct {
+	requestId    string
+	phase        int
+	stateManager StateManager
+}
+
+// StateManager for State Manager
+type StateManager interface {
+	Set(key string, value interface{}) error
+	Get(key string) (interface{}, error)
+	Del(key string) error
+}
+
+// CreateContext create request context (used by template)
+func CreateContext(fchain *Fchain) *Context {
+	context := &Context{}
+	context.requestId = fchain.id
+	context.phase = fchain.chain.ExecutionPosition + 1
+	return context
+}
+
+// SetStateManager sets the state manager
+func (context *Context) SetStateManager(state StateManager) {
+	context.stateManager = state
+}
+
+// GetRequestId returns the request id
+func (context *Context) GetRequestId() string {
+	return context.requestId
+}
+
+// GetPhase return the phase no
+func (context *Context) GetPhase() int {
+	return context.phase
+}
+
+// Set put a value in the context with StateManager
+func (context *Context) Set(key string, data interface{}) error {
+	return context.stateManager.Set(key, data)
+}
+
+// Get retrive a value from the context with StateManager
+func (context *Context) Get(key string) (interface{}, error) {
+	data, err := context.stateManager.Get(key)
+	return data, err
+}
+
+// Del deletes a value from the context with StateManager
+func (context *Context) Del(key string) error {
+	return context.stateManager.Del(key)
+}

--- a/example/upload-chain-async/handler.go
+++ b/example/upload-chain-async/handler.go
@@ -9,6 +9,8 @@ import (
 	"log"
 	"mime/multipart"
 	"net/http"
+	"net/url"
+	"os"
 )
 
 type Dimention struct {
@@ -27,8 +29,17 @@ type FaceResult struct {
 	ImageBase64 string
 }
 
+func getQuery(key string) string {
+	values, err := url.ParseQuery(os.Getenv("Http_Query"))
+	if err != nil {
+		return ""
+	}
+	return values.Get("file")
+
+}
+
 // Upload file upload logic
-func Upload(client *http.Client, url string, filename string, r io.Reader) (err error) {
+func upload(client *http.Client, url string, filename string, r io.Reader) (err error) {
 	// Prepare a form that you will submit to that URL.
 	var b bytes.Buffer
 	w := multipart.NewWriter(&b)
@@ -71,51 +82,79 @@ func Upload(client *http.Client, url string, filename string, r io.Reader) (err 
 	return
 }
 
+// validateFace validate the no of face
+func validateFace(data []byte) error {
+	result := FaceResult{}
+	err := json.Unmarshal(data, &result)
+	if err != nil {
+		return fmt.Errorf("Failed to decode facedetect result, error %v", err)
+	}
+	switch len(result.Faces) {
+	case 0:
+		return fmt.Errorf("No face detected, picture should contain one face")
+	case 1:
+		return nil
+	}
+	return fmt.Errorf("More than one face detected, picture should have single face")
+}
+
 // Handle a serverless request to chain
 func Define(chain *fchain.Fchain, context *fchain.Context) (err error) {
 
 	// Define Chain
 	chain.
 		ApplyModifier(func(data []byte) ([]byte, error) {
-			bytes := "12eeee 24   21312312 ddd2d 31e 1 111ddddd23d2 21e 12"
-			context.Set("raw", []byte(bytes))
-			log.Println(bytes)
-			log.Println(len(data))
+			// Set the name of the file (error if not specified)
+			filename := getQuery("file")
+			if filename != "" {
+				context.Set("file", filename)
+			} else {
+				return nil, fmt.Errorf("Provide file name with `--query file=<name>`")
+			}
+			// Set data to reuse after facedetect
+			context.Set("raw", data)
 			return data, nil
 		}).
 		Apply("facedetect").
 		ApplyModifier(func(data []byte) ([]byte, error) {
-			result := FaceResult{}
-			err := json.Unmarshal(data, &result)
+			// validate face
+			err := validateFace(data)
 			if err != nil {
-				return nil, fmt.Errorf("Failed to decode facedetect result, error %v", err)
+				return nil, err
 			}
-			switch len(result.Faces) {
-			case 0:
-				return nil, fmt.Errorf("No face detected, picture should contain one face")
-			case 1:
-				data, err := context.Get("raw")
-				log.Println(len(data))
-				log.Println(data)
-				b, ok := data.(string)
-				if err != nil || !ok {
-					return nil, fmt.Errorf("Failed to retrive picture from state, error %v %v", err, ok)
-				}
-				log.Println(len(b))
-				log.Println(b)
-				return []byte(b), nil
+			// Get data from context
+			rawdata, err := context.Get("raw")
+			b, ok := rawdata.([]byte)
+			if err != nil || !ok {
+				return nil, fmt.Errorf("Failed to retrive picture from state, error %v %v", err, ok)
 			}
-			return nil, fmt.Errorf("More than one face detected, picture should have single face")
+			return b, err
 		}).
 		Apply("colorization").
 		Apply("image-resizer").
 		ApplyModifier(func(data []byte) ([]byte, error) {
-			err = Upload(&http.Client{}, "http://gateway:8080/function/file-storage",
-				"chris.jpg", bytes.NewReader(data))
+			// get file name from context
+			file, err := context.Get("file")
+			filename, ok := file.(string)
+			if err != nil || !ok {
+				return nil, fmt.Errorf("Failed to get file name in context, %s %v", filename, err)
+			}
+			// upload file to storage
+			err = upload(&http.Client{}, "http://gateway:8080/function/file-storage",
+				filename, bytes.NewReader(data))
 			if err != nil {
 				return nil, err
 			}
 			return nil, nil
+		}).
+		OnFailure(func(err error) {
+			log.Printf("Failed to upload picture for request id %s, error %v",
+				context.GetRequestId(), err)
+		}).
+		Finally(func() {
+			// Optional (cleanup)
+			context.Del("raw")
+			context.Del("file")
 		})
 
 	return nil

--- a/sdk/chain.go
+++ b/sdk/chain.go
@@ -4,12 +4,14 @@ import (
 	"encoding/json"
 )
 
-type Handler func(error)
+type ErrorHandler func(error)
+type Handler func()
 
 type Chain struct {
-	Phases            []*Phase `json:"-"`        // Phases that will be executed in async
-	ExecutionPosition int      `json:"position"` // Position of Executor
-	FailureHandler    Handler  `json:"-"`
+	Phases            []*Phase     `json:"-"`        // Phases that will be executed in async
+	ExecutionPosition int          `json:"position"` // Position of Executor
+	FailureHandler    ErrorHandler `json:"-"`
+	Finally           Handler      `json:"-"`
 }
 
 func CreateChain() *Chain {

--- a/sdk/request.go
+++ b/sdk/request.go
@@ -6,10 +6,11 @@ import (
 )
 
 type Request struct {
-	Sign     string `json: "sign"`
-	ID       string `json: "id"`
-	Data     []byte `json: "data"`
-	Chaindef string `json: "chain-def"`
+	Sign     string                 `json: "sign"`
+	ID       string                 `json: "id"`
+	Data     []byte                 `json: "data"`
+	Chaindef string                 `json: "chain-def"`
+	State    map[string]interface{} `json: "state"`
 }
 
 const (
@@ -17,8 +18,8 @@ const (
 	SIGN = "D9D98C7EBAA7267BCC4F0280FC5BA4273F361B00D422074985A41AE1338F1B61"
 )
 
-func BuildRequest(id string, chaindef string, data []byte) *Request {
-	request := &Request{Sign: SIGN, ID: id, Chaindef: chaindef, Data: data}
+func BuildRequest(id string, chaindef string, data []byte, state map[string]interface{}) *Request {
+	request := &Request{Sign: SIGN, ID: id, Chaindef: chaindef, Data: data, State: state}
 	return request
 }
 
@@ -48,4 +49,8 @@ func (req *Request) GetData() []byte {
 
 func (req *Request) GetID() string {
 	return req.ID
+}
+
+func (req *Request) GetState() map[string]interface{} {
+	return req.State
 }

--- a/template/faaschain/function/handler.go
+++ b/template/faaschain/function/handler.go
@@ -6,7 +6,7 @@ import (
 )
 
 // Handle a serverless request to chian
-func Define(chain *faaschain.Fchain) (err error) {
+func Define(chain *faaschain.Fchain, context *faaschain.Context) (err error) {
 	chain.ApplyModifier(func(data []byte) ([]byte, error) {
 		return []byte(fmt.Sprintf("%s", string(data))), nil
 	}).ApplyModifier(func(data []byte) ([]byte, error) {

--- a/template/faaschain/state_manager.go
+++ b/template/faaschain/state_manager.go
@@ -1,0 +1,45 @@
+package main
+
+import (
+	"fmt"
+)
+
+// json to encode
+type requestEmbedStateManager struct {
+	state map[string]interface{}
+}
+
+// CreateStateManager creates a new requestEmbedStateManager
+func createStateManager() *requestEmbedStateManager {
+	rstate := &requestEmbedStateManager{}
+	rstate.state = make(map[string]interface{})
+	return rstate
+}
+
+// RetriveStateManager creates a state manager from a map
+func retriveStateManager(state map[string]interface{}) *requestEmbedStateManager {
+	rstate := &requestEmbedStateManager{}
+	rstate.state = state
+	return rstate
+}
+
+// Set sets a value (implement StateManager)
+func (rstate *requestEmbedStateManager) Set(key string, value interface{}) error {
+	rstate.state[key] = value
+	return nil
+}
+
+// Get gets a value (implement StateManager)
+func (rstate *requestEmbedStateManager) Get(key string) (interface{}, error) {
+	value, ok := rstate.state[key]
+	if !ok {
+		return nil, fmt.Errorf("No field name %s", key)
+	}
+	return value, nil
+}
+
+// Del delets a value (implement StateManager)
+func (rstate *requestEmbedStateManager) Del(key string) error {
+	delete(rstate.state, key)
+	return nil
+}

--- a/template/faaschain/state_manager.go
+++ b/template/faaschain/state_manager.go
@@ -40,6 +40,8 @@ func (rstate *requestEmbedStateManager) Get(key string) (interface{}, error) {
 
 // Del delets a value (implement StateManager)
 func (rstate *requestEmbedStateManager) Del(key string) error {
-	delete(rstate.state, key)
+	if _, ok := rstate.state[key]; ok {
+		delete(rstate.state, key)
+	}
 	return nil
 }

--- a/template/faaschain/vendor/github.com/s8sg/faaschain/chain.go
+++ b/template/faaschain/vendor/github.com/s8sg/faaschain/chain.go
@@ -6,6 +6,12 @@ import (
 	"path"
 )
 
+type Options struct {
+	header map[string]string
+	query  map[string][]string
+	sync   bool
+}
+
 type Fchain struct {
 	chain    *sdk.Chain
 	id       string
@@ -14,22 +20,9 @@ type Fchain struct {
 	chainDef []byte
 }
 
-type Context struct {
-	phaseInput []byte
-	requestId  string
-	phase      int
-}
-
-type Options struct {
-	header map[string]string
-	query  map[string][]string
-	sync   bool
-}
-
 type Option func(*Options)
 
 var (
-	gContext *Context
 	// Sync can be used instead of SyncCall
 	Sync = SyncCall()
 )
@@ -215,35 +208,4 @@ func (fchain *Fchain) GetUrl() string {
 // GetAsyncUrl returns the URL for the faaschain async function
 func (fchain *Fchain) GetAsyncUrl() string {
 	return fchain.asyncUrl
-}
-
-// CreateGlobalContext create a context for the chain (it's
-func (fchain *Fchain) CreateGlobalContext(request []byte) {
-	if gContext == nil {
-		context := &Context{}
-		context.phaseInput = request
-		context.requestId = fchain.id
-		context.phase = fchain.chain.ExecutionPosition + 1
-		gContext = context
-	}
-}
-
-// GetContext returns the global context that was created
-func GetContext() Context {
-	return *gContext
-}
-
-// GetPhaseInput returns the phase input (it allows to user replay a data )
-func (context Context) GetPhaseInput() []byte {
-	return context.phaseInput
-}
-
-// GetRequestId returns the request id
-func (context Context) GetRequestId() string {
-	return context.requestId
-}
-
-// GetPhase return the phase no
-func (context Context) GetPhase() int {
-	return context.phase
 }

--- a/template/faaschain/vendor/github.com/s8sg/faaschain/context.go
+++ b/template/faaschain/vendor/github.com/s8sg/faaschain/context.go
@@ -5,6 +5,7 @@ type Context struct {
 	requestId    string
 	phase        int
 	stateManager StateManager
+	State        string
 }
 
 // StateManager for State Manager
@@ -14,11 +15,18 @@ type StateManager interface {
 	Del(key string) error
 }
 
-// Create Context
+const (
+	StateSuccess = "success"
+	StateFailure = "failure"
+	StateOngoing = "ongoing"
+)
+
+// CreateContext create request context (used by template)
 func CreateContext(fchain *Fchain) *Context {
 	context := &Context{}
 	context.requestId = fchain.id
 	context.phase = fchain.chain.ExecutionPosition + 1
+	context.State = StateOngoing
 	return context
 }
 

--- a/template/faaschain/vendor/github.com/s8sg/faaschain/context.go
+++ b/template/faaschain/vendor/github.com/s8sg/faaschain/context.go
@@ -1,0 +1,54 @@
+package faaschain
+
+// Context execution context and execution state
+type Context struct {
+	requestId    string
+	phase        int
+	stateManager StateManager
+}
+
+// StateManager for State Manager
+type StateManager interface {
+	Set(key string, value interface{}) error
+	Get(key string) (interface{}, error)
+	Del(key string) error
+}
+
+// Create Context
+func CreateContext(fchain *Fchain) *Context {
+	context := &Context{}
+	context.requestId = fchain.id
+	context.phase = fchain.chain.ExecutionPosition + 1
+	return context
+}
+
+// SetStateManager sets the state manager
+func (context *Context) SetStateManager(state StateManager) {
+	context.stateManager = state
+}
+
+// GetRequestId returns the request id
+func (context *Context) GetRequestId() string {
+	return context.requestId
+}
+
+// GetPhase return the phase no
+func (context *Context) GetPhase() int {
+	return context.phase
+}
+
+// Set put a value in the context with StateManager
+func (context *Context) Set(key string, data interface{}) error {
+	return context.stateManager.Set(key, data)
+}
+
+// Get retrive a value from the context with StateManager
+func (context *Context) Get(key string) (interface{}, error) {
+	data, err := context.stateManager.Get(key)
+	return data, err
+}
+
+// Del deletes a value from the context with StateManager
+func (context *Context) Del(key string) error {
+	return context.stateManager.Del(key)
+}

--- a/template/faaschain/vendor/github.com/s8sg/faaschain/sdk/chain.go
+++ b/template/faaschain/vendor/github.com/s8sg/faaschain/sdk/chain.go
@@ -4,12 +4,14 @@ import (
 	"encoding/json"
 )
 
-type Handler func(error)
+type ErrorHandler func(error)
+type Handler func()
 
 type Chain struct {
-	Phases            []*Phase `json:"-"`        // Phases that will be executed in async
-	ExecutionPosition int      `json:"position"` // Position of Executor
-	FailureHandler    Handler  `json:"-"`
+	Phases            []*Phase     `json:"-"`        // Phases that will be executed in async
+	ExecutionPosition int          `json:"position"` // Position of Executor
+	FailureHandler    ErrorHandler `json:"-"`
+	Finally           Handler      `json:"-"`
 }
 
 func CreateChain() *Chain {

--- a/template/faaschain/vendor/github.com/s8sg/faaschain/sdk/request.go
+++ b/template/faaschain/vendor/github.com/s8sg/faaschain/sdk/request.go
@@ -6,10 +6,11 @@ import (
 )
 
 type Request struct {
-	Sign     string `json: "sign"`
-	ID       string `json: "id"`
-	Data     []byte `json: "data"`
-	Chaindef string `json: "chain-def"`
+	Sign     string                 `json: "sign"`
+	ID       string                 `json: "id"`
+	Data     []byte                 `json: "data"`
+	Chaindef string                 `json: "chain-def"`
+	State    map[string]interface{} `json: "state"`
 }
 
 const (
@@ -17,8 +18,8 @@ const (
 	SIGN = "D9D98C7EBAA7267BCC4F0280FC5BA4273F361B00D422074985A41AE1338F1B61"
 )
 
-func BuildRequest(id string, chaindef string, data []byte) *Request {
-	request := &Request{Sign: SIGN, ID: id, Chaindef: chaindef, Data: data}
+func BuildRequest(id string, chaindef string, data []byte, state map[string]interface{}) *Request {
+	request := &Request{Sign: SIGN, ID: id, Chaindef: chaindef, Data: data, State: state}
 	return request
 }
 
@@ -48,4 +49,8 @@ func (req *Request) GetData() []byte {
 
 func (req *Request) GetID() string {
 	return req.ID
+}
+
+func (req *Request) GetState() map[string]interface{} {
+	return req.State
 }


### PR DESCRIPTION
This PR solves issues #3 
and add `Finally()`

## Context
Context provides the request context with state, Context get passed in `Define()` Function
```go
func Define(chain *faaschain.Fchain, context *faaschain.Context) (err error) {
// definition
}
the context provides:
```go
type Context struct {
	requestId    string
	phase        int
	stateManager StateManager
	State        string
}
```
and `Get()` method 

State provide the Pipeline State as:
```go

StateOngoing
StateSuccess
StateFailure
```

    
## StateManager    
State manager provides the interface to manage state
```go
// StateManager for State Manager
type StateManager interface {
	Set(key string, value interface{}) error
	Get(key string) (interface{}, error)
	Del(key string) error
}
```
    
`requestEmbedStateManager` is the default state manager that implements the state with `Json` and forwards the data with request
           
A user define state can be set as 
```go
context.SetStateManager(MinioStateManager)
``` 
     
Context abstracts the state manager as
```go
context.Set("key", value)
context.Get("key")
context.Del("key")
```
      
## Finally
Finally allows user to run a piece of code when the pipeline is finished. Finally gets called if the pipeline state is `StateSuccess` or `StateFailure`. The state can be retrieved from `context` as:
```go
    .Finally(func() {
          if context.State == faaschain. StateSuccess {
               // Do success related work
          } else {
              // Do failure handler
          }
    })
```